### PR TITLE
Update SDL2 Audio functions to AudioDevice equivalents

### DIFF
--- a/source/main.cc
+++ b/source/main.cc
@@ -47,7 +47,7 @@ char cmd_line[1024];
 
 void delete_obj();
 
-char exe_directory[1024];
+const char *exe_directory = NULL;
 #undef main
 extern "C" int main(int ARGC, char **ARGV) {
   SDL_Init(SDL_INIT_VIDEO|SDL_INIT_AUDIO);
@@ -67,17 +67,10 @@ extern "C" int main(int ARGC, char **ARGV) {
 			skelton_msgbox("SIGPIPE handler isn't default, ignoring.\n");
 #endif
 
-	//Copy the whole thing
-    strncpy(exe_directory, ARGV[0], sizeof(exe_directory));
-	exe_directory[sizeof(exe_directory)-1]=0;
-	//Remove file name and final last /
-#ifdef WIN32
-    char *temp = strrchr(exe_directory, '\\');
-#else
-    char *temp = strrchr(exe_directory, '/');
-#endif
-	if(temp)
-		*temp=0;
+  exe_directory = SDL_GetBasePath();
+  if (!exe_directory) {
+    fatal_msgbox("Failed to get base path: %s\n", SDL_GetError()); 
+  }
 
   for(int i=1; i<ARGC; i++) {
     command.add(ARGV[i]);
@@ -120,6 +113,7 @@ void delete_obj() {
     delete cursor;
     cursor=NULL;
   }
+  SDL_free((void *)exe_directory);
   SDL_Quit();
   msgbox("ending delete_obj...\n");
 }

--- a/source/main.h
+++ b/source/main.h
@@ -38,6 +38,6 @@ enum Time_mode {
 
 extern Time_mode time_control;
 
-extern char exe_directory[];
+extern const char *exe_directory;
 
 #endif

--- a/source/quadra.cc
+++ b/source/quadra.cc
@@ -612,22 +612,16 @@ int start_game() {
 	init_directory();
 
 	const char *dir=quadradir;
-#ifdef WIN32
-	dir = exe_directory;
-#else
-	dir = getenv("QUADRADIR");
-#ifdef ENABLE_APP_BUNDLE
-	// TODO(pphaneuf): We're leaking the string returned by SDL_GetBasePath.
-	if(!dir)
-		dir = SDL_GetBasePath();
+#ifdef DATAGAMESDIR
+  dir = DATAGAMESDIR;
 #endif
-	if(!dir)
-		dir = DATAGAMESDIR;
-#endif
+  dir = getenv("QUADRADIR");
+	if(!dir) dir = exe_directory;
+  
 	resmanager=new Resmanager();
-	snprintf(fn, sizeof(fn) - 1, "%s/quadra.res", dir);
+	snprintf(fn, sizeof(fn) - 1, "%squadra.res", dir);
 	resmanager->loadresfile(fn);
-	snprintf(fn, sizeof(fn) - 1, "%s/quadra%i%i%i.res", dir, Config::major, Config::minor, Config::patchlevel);
+	snprintf(fn, sizeof(fn) - 1, "%squadra%i%i%i.res", dir, Config::major, Config::minor, Config::patchlevel);
 	resmanager->loadresfile(fn);
 	if(command.token("patch") || command.token("theme")) {
 		const char *temp=command_get_param("patch <filename>");

--- a/source/res.cc
+++ b/source/res.cc
@@ -46,7 +46,9 @@ Res_dos::Res_dos(const char *fil, Res_mode mode) {
 		  flag = O_CREAT|O_TRUNC|O_RDWR;
 		  break;
 	}
-    flag |= O_BINARY;
+  #ifdef WIN32
+  flag |= O_BINARY;
+  #endif
 	handle = open(fil, flag, 0666);
 	if(handle == -1) {
 		if(mode == RES_TRY || mode == RES_CREATE)

--- a/source/sound.h
+++ b/source/sound.h
@@ -32,9 +32,10 @@ class SampleData;
 
 class Sound {
   SDL_AudioSpec spec;
+  SDL_AudioDeviceID device;
 	std::vector<Playing_sfx*> plays;
 	static void audio_callback(void *userdata, Uint8 *stream, int len);
-	Sound(const SDL_AudioSpec& _spec);
+	Sound(const SDL_AudioSpec& _spec, const SDL_AudioDeviceID _device);
 public:
   static Sound* New();
   SampleData* normalize(char* _sample, unsigned int _size,

--- a/source/video.cc
+++ b/source/video.cc
@@ -31,13 +31,15 @@
 
 Video* video = NULL;
 
-static SDL_Renderer* CreateRenderer(SDL_Window* window) {
+static SDL_Renderer* CreateRenderer(SDL_Window* window, int w, int h) {
   SDL_Renderer* renderer(
     SDL_CreateRenderer(window, -1, SDL_RENDERER_PRESENTVSYNC));
 
   // If we couldn't get a renderer that supports vsync, get whatever we can.
   if (!renderer)
     renderer = SDL_CreateRenderer(window, -1, 0);
+
+  SDL_RenderSetLogicalSize(renderer, w, h);
 
   return renderer;
 }
@@ -48,8 +50,8 @@ public:
     : Video(new Video_bitmap_SDL(this, 0, 0, w, h), w, h, w),
       window_(SDL_CreateWindow(
         "Quadra", SDL_WINDOWPOS_CENTERED,SDL_WINDOWPOS_CENTERED, w, h, fullscreen ?
-            SDL_WINDOW_FULLSCREEN|SDL_WINDOW_INPUT_GRABBED : 0)),
-      renderer_(CreateRenderer(window_)),
+            SDL_WINDOW_FULLSCREEN_DESKTOP|SDL_WINDOW_INPUT_GRABBED : 0)),
+      renderer_(CreateRenderer(window_, w, h)),
       texture_(SDL_CreateTexture(
         renderer_, SDL_GetWindowPixelFormat(window_),
         SDL_TEXTUREACCESS_STREAMING, w, h)),


### PR DESCRIPTION
These changes restore audio playback to Quadra binaries compiled for recent Windows versions.

As I understand  it SDL was asking Windows for a certain type of audio buffer and Windows was not giving it the right one, or it was and then immediately changing its mind. Something stupid like that.

The change that fixes the root problem is using the function `SDL_OpenAudioDevice` and passing `0` as the fifth argument, which explicitly tells the operating system that it isn't allowed to deviate from the requested audio spec at all.

See [the SDL2 wiki](https://wiki.libsdl.org/SDL2/SDL_OpenAudioDevice) for a proper explanation, most of the clever thinking in these changes was actually done by a friend of mine who knows SDL (I don't).